### PR TITLE
Bunzip2 -> Unbzip2; Gunzip -> Ungzip

### DIFF
--- a/extract/extract.go
+++ b/extract/extract.go
@@ -102,7 +102,7 @@ func handleZip(a *Archive, outputPath string, filters FilterSet, overwrite bool)
 
 func handleTbz2(a *Archive, outputPath string, filters FilterSet, overwrite bool) error {
 	log.Infof("extracting (tbz2) %s", a.Path)
-	if err := a.Bunzip2(); err != nil {
+	if err := a.Unbzip2(); err != nil {
 		return fmt.Errorf("uncompressing (bzip2) %s failed; error: %s", a.Path, err)
 	}
 	extractedFiles := a.Untar(outputPath, filters, overwrite)
@@ -114,7 +114,7 @@ func handleTbz2(a *Archive, outputPath string, filters FilterSet, overwrite bool
 
 func handleTgz(a *Archive, outputPath string, filters FilterSet, overwrite bool) error {
 	log.Infof("extracting (tgz) %s", a.Path)
-	if err := a.Gunzip(); err != nil {
+	if err := a.Ungzip(); err != nil {
 		return fmt.Errorf("uncompressing (gzip) %s failed; error: %s", a.Path, err)
 	}
 	extractedFiles := a.Untar(outputPath, filters, overwrite)
@@ -138,7 +138,7 @@ func handleTxz(a *Archive, outputPath string, filters FilterSet, overwrite bool)
 
 func handleBz2(a *Archive, outputPath string, filters FilterSet, overwrite bool) error {
 	log.Infof("extracting (bz2) %s", a.Path)
-	if err := a.Bunzip2(); err != nil {
+	if err := a.Unbzip2(); err != nil {
 		return fmt.Errorf("uncompressing (bz2) %s failed; error: %s", a.Path, err)
 	}
 	if err := a.WriteSingleton(a.PathNoExt, a.FileStats.Mode().Perm(), overwrite); err != nil {
@@ -149,7 +149,7 @@ func handleBz2(a *Archive, outputPath string, filters FilterSet, overwrite bool)
 
 func handleGz(a *Archive, outputPath string, filters FilterSet, overwrite bool) error {
 	log.Infof("extracting (gz) %s", a.Path)
-	if err := a.Gunzip(); err != nil {
+	if err := a.Ungzip(); err != nil {
 		return fmt.Errorf("uncompressing (gz) %s failed; error: %s", a.Path, err)
 	}
 	if err := a.WriteSingleton(a.PathNoExt, a.FileStats.Mode().Perm(), overwrite); err != nil {

--- a/extract/stream_bzip2.go
+++ b/extract/stream_bzip2.go
@@ -5,10 +5,10 @@ import (
 	"io/ioutil"
 )
 
-// Bunzip2 enables bzip2 decompression of the Archive data. It creates a bzip2
+// Unbzip2 enables bzip2 decompression of the Archive data. It creates a bzip2
 // stream reader for Archive.FileHandle on Archive.StreamHandle. Any errors
 // creating the reader will be returned.
-func (a *Archive) Bunzip2() error {
+func (a *Archive) Unbzip2() error {
 	// https://pkg.go.dev/compress/bzip2
 	a.StreamHandle = ioutil.NopCloser(bzip2.NewReader(a.FileHandle))
 	return nil

--- a/extract/stream_gzip.go
+++ b/extract/stream_gzip.go
@@ -4,10 +4,10 @@ import (
 	"compress/gzip"
 )
 
-// Gunzip enables gzip decompression of the Archive data. It creates a gzip stream
+// Ungzip enables gzip decompression of the Archive data. It creates a gzip stream
 // reader for Archive.FileHandle on Archive.StreamHandle. Any errors creating
 // the reader will be returned.
-func (a *Archive) Gunzip() error {
+func (a *Archive) Ungzip() error {
 	// https://pkg.go.dev/compress/gzip@go1.20.1#example-package-WriterReader
 	// Note the caller needs to close the reader
 	zr, err := gzip.NewReader(a.FileHandle)


### PR DESCRIPTION
This name refactoring makes better sense when viewed in the docs at places like: <https://pkg.go.dev/github.com/backplane/ghlatest/extract>