### PR TITLE
improve amd64 and non-64-bit arm matching

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,11 +38,11 @@ func init() {
 
 	switch runtime.GOARCH {
 	case `amd64`:
-		arch_subregex = `(amd64|x86_64)`
+		arch_subregex = `(amd64|x64|x86_64)`
 	case `arm64`:
 		arch_subregex = `(arm64|aarch64)`
 	case `arm`:
-		arch_subregex = `arm(v[\d\w]{2,3})?`
+		arch_subregex = `(arm(v[\d]{,2}|\w{2,3})?|aarch32)`
 	default:
 		arch_subregex = runtime.GOARCH
 	}


### PR DESCRIPTION
hit a couple of cases where `--current-arch` didn't match when it could have, these adjustments should fix a few of those cases